### PR TITLE
fix(Logsheet): second attempt at correcting row update race conditions

### DIFF
--- a/src/components/Logsheet/Logsheet.jsx
+++ b/src/components/Logsheet/Logsheet.jsx
@@ -116,12 +116,14 @@ function Logsheet() {
 		let newLogObjs = JSON.parse(newLogJson)
 		let updatedMatrix = {}
 
-		Object.entries(newLogObjs).forEach(([id, incomingData]) => {
-			let curLog = logMatrix[id]
+		Object.entries(newLogObjs).map(([id, data]) => (
+			setLogMatrix((prevMatrix) => {
+				let curLog = prevMatrix[id]
+				updatedMatrix[id] = { ...curLog, ...data }
 
-			updatedMatrix[id] = { ...curLog, ...incomingData }
-			setLogMatrix((prevMatrix) => ({ ...prevMatrix, ...updatedMatrix }))
-		})
+				return { ...prevMatrix, ...updatedMatrix }
+			})
+		))
 	})
 
 


### PR DESCRIPTION
Problem: The functionality that updates specific
row cells in the Logsheet oftentimes has race
conditions which distort the data. It is currently specifically on the first new row of a batch and
only when the progress updates. at fixing that.

Solution: Attempt to mitigate this using
functional updates.