### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Issue Report
+description: Report a problem with functionality, documentation, and otherwise
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        _Before reporting_ an issue, please search the [standing issues](https://github.com/Empyrean-Capstone/Empyrean/issues) and check the [Q & A](https://github.com/Empyrean-Capstone/Empyrean/discussions/categories/q-a) for duplicates. Please redirect any usage or "How to" questions to the aforementioned Q & A space. If asked here, they will be closed and reopened there.
+
+  - type: textarea
+    attributes:
+      label: "Problem"
+      description: "Describe the current, undesired behavior. May include stack traces, images, videos, et cetera."
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Steps to reproduce"
+      description: "Describe exactly how to reproduce the undesired behavior."
+      placeholder: |
+        1. start an observation
+        2. click a link
+        3. …
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Expected behavior"
+      description: "Describe the behavior you expect."
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: "Operating system/version"
+      placeholder: "macOS 11.5"
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: "Browser name/version"
+      placeholder: "Chrome 112.0.5615.62"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+- name: Questions
+  url: https://github.com/Empyrean-Capstone/Empyrean/discussions/categories/q-a
+  about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature Request
+description: Request an enhancement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        _Before requesting_ an enhancement, please search the [standing enhancement requests](https://github.com/Empyrean-Capstone/Empyrean/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement) and check the [discussion](https://github.com/Empyrean-Capstone/Empyrean/discussions/) for duplicates.
+
+  - type: textarea
+    attributes:
+      label: "Current behavior"
+      description: "Provide a description of what the application currently does or lacks to motivate the desired behavior."
+      placeholder: "This program doesn't make coffee, but it should because…"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Desired behavior"
+      description: "Describe what the new feature or behavior would look like. How does it solve the problem?"
+    validations:
+      required: true


### PR DESCRIPTION
[Issue templates and forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) help funnel user interaction with the repository into managed routes, preventing users from creating errant or unhelpful requests of the maintainers. 

This PR initializes a bug report template, a feature request template, and a configuration for the template choice screen that disallows users from creating untemplated issues.