### PR TITLE
fix(Stop): rename "obs_id" -> "Observation ID"

### DIFF
--- a/api/main/status/views.py
+++ b/api/main/status/views.py
@@ -35,7 +35,10 @@ def get_current_obsid() -> int:
 
     # There is a status that every camera must have and update which is
     # the id of the observation being taken
-    cur_camera_status = Status.query.filter_by(instrumentID=cur_camera_id, statusName="obs_id").first()
+    cur_camera_status = Status.query.filter_by(
+        instrumentID=cur_camera_id,
+        statusName="Observation ID"
+    ).first()
 
     cur_obsid: int = int(cur_camera_status.statusValue)
 


### PR DESCRIPTION
The refactor to the camera statuses broke the
stopping functionality. This restores it by
updating the status name to search for in finding
the current observation ID.