### PR TITLE
fix(observation form): persist access to form

### DIFF
--- a/api/main/file_writing/views.py
+++ b/api/main/file_writing/views.py
@@ -66,7 +66,7 @@ def __read_image_file(image_path: str) -> np.ndarray:
 
 def __init_header_data_unit(image: np.ndarray, exposure_data: dict, request_input: dict, filename: str):
     def enter_request_input(hdu, input: dict):
-        hdu.header["OBSERVER"] = input["name"]
+        hdu.header["OBSERVER"] = input["observer"]
 
         # TODO: whats the difference between this and IMAGETYP?
         hdu.header["OBSTYPE"] = {
@@ -123,7 +123,6 @@ def __update_db_cols(headers, request_input: dict) -> dict:
     cols = {
         "id": headers["OBSID"],
         "observer": headers["OBSERVER"],
-        "owner_id": request_input["userid"],
         "obs_type": headers["OBSTYPE"],
         "exp_time": headers["EXPTIME"],
         "image_typ": headers["IMAGETYP"],

--- a/api/main/models/status.py
+++ b/api/main/models/status.py
@@ -46,5 +46,18 @@ class Status(db.Model):
             "instrumentID": self.instrumentID,
             "statusName": self.statusName,
             "statusValue": self.statusValue,
-            "color": self.color
+            "color": self.color,
         }
+
+    def set_attrs(self, attrs: dict):
+        """
+        For all of the attributes, sets their value to the default value given
+
+        Parameters:
+        -----------
+            attrs: dict
+                The values to set the user's attributes to
+        """
+
+        for key, val in attrs.items():
+            setattr(self, key, val)

--- a/src/components/Observe/Observe.jsx
+++ b/src/components/Observe/Observe.jsx
@@ -89,15 +89,44 @@ function Observe() {
 
 	const props = { values, handleFieldChange }
 
-	const [isFormEnabled, setFormEnabled] = React.useState(true)
+	const [isFormEnabled, setFormEnabled] = React.useState()
+	const [isStopEnabled, setStopEnabled] = React.useState()
 
 	const socket = useContext(SocketContext);
 
+
+	const getSystemStatus = async () => {
+		try {
+			await axios.get(
+				`/api/status/is_system_busy`,
+				null,
+				{
+					withCredentials: true
+				}
+			)
+		}
+		catch (error) {
+			console.error(error)
+		}
+	}
+
 	useEffect(() => {
-		socket.on("enable_request_form", () => {
+		getSystemStatus()
+	}, [])
+
+	function setForm(status, isBatchOwner) {
+		if (status === "Ready") {
 			setFormEnabled(true)
-		})
-	}, [socket, setFormEnabled])
+		}
+
+		else if (isBatchOwner) {
+			setStopEnabled(true)
+		}
+	}
+
+	socket.on("update_request_form", (systemStatus, isBatchOwner) => {
+		setForm(systemStatus, isBatchOwner)
+	})
 
 
 	const fields_row1 = [
@@ -359,7 +388,7 @@ function Observe() {
 
 							loadingPosition="center"
 							loading={isLoading === "Stop"}
-							disabled={isFormEnabled}
+							disabled={isFormEnabled || !isStopEnabled}
 						>
 							Stop
 						</LoadingButton>


### PR DESCRIPTION
Problem: Access to the observation form does not
persist across page navigation or log out. For
example, if the user starts an observation and
changes pages, they can no longer access the
"Stop" button to terminate the observation.

Solution: When navigating to the observation
request page, check if the system is currently
busy using a new "System" status. If not, allow
all users access to the form. If it is busy, check if the current user is the owner of the current
observation. If so, allow them access to the
"Stop" button. If not, deny access to the form
submission and termination buttons.