### PR TITLE
ci: add paths to PR workflows

### DIFF
--- a/.github/workflows/build_services.yml
+++ b/.github/workflows/build_services.yml
@@ -4,7 +4,7 @@
 
 name: Containerization Health
 on:
-  push:
+  pull_request:
     branches: ["main"]
     paths:
       - "package.json"
@@ -13,9 +13,6 @@ on:
       - "api/**"
       - "instrument_interfaces/**"
       - ".github/workflows/**"
-
-  pull_request:
-    branches: ["main"]
 
 jobs:
   build_containers:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -5,14 +5,12 @@
 
 name: Node Build Health
 on:
-  push:
-    branches: ["main", "ci-cd"]
+  pull_request:
+    branches: ["main"]
     paths:
       - "package.json"
       - "src/**"
       - ".github/workflows/**"
-  pull_request:
-    branches: ["main"]
 
 jobs:
   build_frontend:


### PR DESCRIPTION
Branch protection rules have been added to main.
Remove "push" events to main because they are
consequently unnecessary.

Add paths to the "pull_request" events, so that
workflows only run when certain paths are
changed. This was the intended effect of fe5a7beb46cc1bcdfaaa89a935117ca5b424e387 
but I accidentally only added them to the "push" event.